### PR TITLE
Removed allow backup

### DIFF
--- a/rx_paparazzo/src/main/AndroidManifest.xml
+++ b/rx_paparazzo/src/main/AndroidManifest.xml
@@ -6,7 +6,7 @@
   <uses-permission android:name="android.permission.INTERNET"/>
 
   <application
-      android:allowBackup="true"
+      android:allowBackup="false"
       android:label="@string/app_name"
       android:supportsRtl="true">
 


### PR DESCRIPTION
Avoiding merge manifest errors if the application has disabled this feature. `tools:replace="allowBackup` does not always work