### PR TITLE
Fix crash when link to target activity is gone

### DIFF
--- a/rx_paparazzo/src/main/java/com/miguelbcr/ui/rx_paparazzo/interactors/GetPath.java
+++ b/rx_paparazzo/src/main/java/com/miguelbcr/ui/rx_paparazzo/interactors/GetPath.java
@@ -52,6 +52,10 @@ public final class GetPath extends UseCase<String> {
     Context context = targetUi.activity();
     String filePath = null;
 
+    if (context == null) {
+      return Observable.just("");
+    }
+
     if (uri == null) {
       return null;
     }


### PR DESCRIPTION
For details see #61 